### PR TITLE
fix spell errors and missing header file

### DIFF
--- a/sample_programs/README.md
+++ b/sample_programs/README.md
@@ -1,4 +1,4 @@
-# How to compiler and run these programs
+# How to compile and run these programs
 
 ## Allocate Computing Resources
 ```bash
@@ -41,7 +41,7 @@ srun -n 4 ./pthread_hello
 ## OpenMP
 ```bash
 # Compilation
-g++ -fopenmp openmp_hello.cpp -o openmp_hellp
+g++ -fopenmp openmp_hello.cpp -o openmp_hello
 # Execution
 srun -n 4 ./openmp_hello
 ```

--- a/sample_programs/pthread_hello.cpp
+++ b/sample_programs/pthread_hello.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <pthread.h>
+#include <cstdlib>
 
 #define NUM_THREADS 4
 


### PR DESCRIPTION
With these changes, sample codes of OpenMP and Pthread can compile and run normally.