### PR TITLE
Update install guide for Nvidia-card container

### DIFF
--- a/docs/docker_installation_guide.md
+++ b/docs/docker_installation_guide.md
@@ -109,8 +109,14 @@ docker exec -it <CONTAINER ID> bash
 
 # Now, you can interact with the docker container just like a normal linux machine.
 # You need to do some manipulations on the system path for your nvcc and pgc++ to work as expected
-echo 'export PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.7/cuda/11.4/bin:$PATH' >> ~/.bashrc
+echo export 'LD_LIBRARY_PATH'=`echo $LD_LIBRARY_PATH`:'$LD_LIBRARY_PATH' >> ~/.bashrc
+echo export 'PATH'=`echo $PATH`:'$PATH' >> ~/.bashrc
+
 source ~/.bashrc
+
+# Check if there are a long string output:
+echo $PATH
+echo $LD_LIBRARY_PATH
 
 # We should see expected output for the following commands
 nvcc --version
@@ -133,6 +139,9 @@ nvc++ --version
 # To compile OpenACC program in the container, you need to explicitly specify the CUDA version
 # On the cluster, you don't need this '-gpu cuda11.4' flag
 pgc++ -gpu cuda11.4 -acc -mp ./openacc_parallel.cpp -o openacc_parallel
+
+# To run mpi program in the container, you need use the following command:
+mpirun -n 4 --allow-run-as-root ./mpi_hello
 ```
 
 ### If your laptop does not have NVIDIA card equipped


### PR DESCRIPTION
**Changes:**

According to the [issue 10](https://github.com/tonyyxliu/CSC4005-2023Fall/issues/10), I fixed the installation guide for Nvidia-card container, which makes ssh terminal can found $PATH and $LD_LIBRARY_PATH variable. Therefore, the students' now can compile and run the code properly through VSCode, which relies on ssh. And, we don't need the original line, actually. 

In addition, I found that mpi_hello cannot be executed correctly in the container, the correct way in the docker is through `mpirun`. I fixed it as well.

**Tests:**

I had created a new docker image, and test my new fixed commands. They work for ssh terminal. Now, all programs (except avx512f due to low g++ version), can be compiled successfully through terminal in ssh.

I tried on the CPU-only image. That basically has no problem like this.

**Effects Demo:**

Originally in VSCode's terminal:

![image](https://github.com/tonyyxliu/CSC4005-2023Fall/assets/74816944/e7d2545d-ef49-453f-b743-a075a67d567c)

Now with my added lines of command (`nvcc`, `pgc++` etc. can be found):

![image](https://github.com/tonyyxliu/CSC4005-2023Fall/assets/74816944/bb971d03-4ec0-47f8-837d-644096021133)

All works well then.

Thanks!