### PR TITLE
Clean Openacc code

### DIFF
--- a/project1/src/gpu/openacc_PartA.cpp
+++ b/project1/src/gpu/openacc_PartA.cpp
@@ -28,17 +28,13 @@ int main(int argc, char **argv)
     int width = input_jpeg.width;
     int height = input_jpeg.height;
     int num_channels = input_jpeg.num_channels;
+    unsigned char *buffer = input_jpeg.buffer;
     unsigned char *grayImage = new unsigned char[width * height];
-    unsigned char *buffer = new unsigned char[width * height * num_channels];
-    for (int i = 0; i < width * height * num_channels; i++)
-    {
-        buffer[i] = input_jpeg.buffer[i];
-    }
 #pragma acc enter data copyin(grayImage[0 : width * height], \
                               buffer[0 : width * height * num_channels])
 
 #pragma acc update device(grayImage[0 : width * height], \
-                          buffer[0 : width * height * num_channels])
+                              buffer[0 : width * height * num_channels])
 
     auto start_time = std::chrono::high_resolution_clock::now();
 #pragma acc parallel present(grayImage[0 : width * height],             \
@@ -75,7 +71,6 @@ int main(int argc, char **argv)
     // Release allocated memory
     delete[] input_jpeg.buffer;
     delete[] grayImage;
-    delete[] buffer;
     std::cout << "Transformation Complete!" << std::endl;
     std::cout << "Execution Time: " << elapsed_time.count()
               << " milliseconds\n";

--- a/project1/src/gpu/openacc_PartA.cpp
+++ b/project1/src/gpu/openacc_PartA.cpp
@@ -33,9 +33,6 @@ int main(int argc, char **argv)
 #pragma acc enter data copyin(grayImage[0 : width * height], \
                               buffer[0 : width * height * num_channels])
 
-#pragma acc update device(grayImage[0 : width * height], \
-                              buffer[0 : width * height * num_channels])
-
     auto start_time = std::chrono::high_resolution_clock::now();
 #pragma acc parallel present(grayImage[0 : width * height],             \
                              buffer[0 : width * height * num_channels]) \
@@ -50,8 +47,6 @@ int main(int argc, char **argv)
         }
     }
     auto end_time = std::chrono::high_resolution_clock::now();
-#pragma acc update self(grayImage[0 : width * height], \
-                        buffer[0 : width * height * num_channels])
 
 #pragma acc exit data copyout(grayImage[0 : width * height])
 


### PR DESCRIPTION
It seems to me open-acc code contains quite a bit of confusing commands.

- `buffer` clone: seems to me no need to do this memory copy.
- `update directive`: seems to me no need to update, as after the data being just copied to device host there is no new update.
- `copyout`: I doubt `copyout` is correctly used: please refer to [openacc-guide.pdf](https://www.openacc.org/sites/default/files/inline-files/openacc-guide.pdf): "copyout - Create space for the listed variables on the device but do not initialize them. At the end of the region, copy the results back to the host and release the space on the device."
- `parallel` region: we have only a single parallel loop, so just use `acc parallel loop`.
- `present`: unnecessary following `copyin`.
