### PR TITLE
Use move semantics for Matrix

### DIFF
--- a/project2/src/matrix.cpp
+++ b/project2/src/matrix.cpp
@@ -25,10 +25,12 @@ Matrix::Matrix(size_t rows, size_t cols) : rows(rows), cols(cols) {
 
 Matrix::~Matrix() {
     // Destructor to free memory
-    for (size_t i = 0; i < rows; ++i) {
-        delete[] data[i];
+    if (data != nullptr) {
+        for (size_t i = 0; i < rows; ++i) {
+            delete[] data[i];
+        }
+        delete[] data;
     }
-    delete[] data;
 }
 
 int* Matrix::operator[](size_t rowIndex) {
@@ -102,4 +104,32 @@ void Matrix::saveToFile(const std::string& filename) const {
     }
 
     outputFile.close();
+}
+
+Matrix::Matrix(Matrix&& other) noexcept {
+    data = other.data;
+    rows = other.rows;
+    cols = other.cols;
+    other.data = nullptr;
+    other.rows = 0;
+    other.cols = 0;
+}
+
+Matrix& Matrix::operator=(Matrix&& other) noexcept {
+    // Free the memory of the current object
+    if (data != nullptr) {
+        for (size_t i = 0; i < rows; ++i) {
+            delete[] data[i];
+        }
+        delete[] data;
+    }
+    // Move the data from the other object
+    data = other.data;
+    rows = other.rows;
+    cols = other.cols;
+    // Reset the other object
+    other.data = nullptr;
+    other.rows = 0;
+    other.cols = 0;
+    return *this;
 }

--- a/project2/src/matrix.cpp
+++ b/project2/src/matrix.cpp
@@ -116,6 +116,10 @@ Matrix::Matrix(Matrix&& other) noexcept {
 }
 
 Matrix& Matrix::operator=(Matrix&& other) noexcept {
+    // prevent self-assignment
+    if (this == &other) {
+        return *this;
+    }
     // Free the memory of the current object
     if (data != nullptr) {
         for (size_t i = 0; i < rows; ++i) {

--- a/project2/src/matrix.hpp
+++ b/project2/src/matrix.hpp
@@ -44,6 +44,14 @@ class Matrix {
 
     // Save a matrix to a file
     void saveToFile(const std::string& filename) const;
+
+    // disable copy
+    Matrix(const Matrix&) = delete;
+    Matrix& operator=(const Matrix&) = delete;
+
+    // enable move
+    Matrix(Matrix&&) noexcept;
+    Matrix& operator=(Matrix&&) noexcept;
 };
 
 #endif


### PR DESCRIPTION
Currently, `Matrix a = b;` causes segmentation fault due to double free.

This commit disables copy assignment, and enables move semantics.

Discussion is freely welcomed, and any suggestion to modify this PR will be respected too. As far as I know, this commit is compatible with the existing use cases of Matrix class in Project2.