### PR TITLE
docs: renew HPC ip in instructions for semester 2410 (2024-25 Fall)

### DIFF
--- a/docs/Instruction on Passwordlessly Connecting to Cluster by Setting Up SSH Key Authentification.md
+++ b/docs/Instruction on Passwordlessly Connecting to Cluster by Setting Up SSH Key Authentification.md
@@ -1,9 +1,11 @@
 # Instruction on Passwordlessly Connecting to Cluster by Setting Up SSH Key Authentification
 
 ## Preface
+
 This instruction is for students who suffer from typing the complicated password every time to login the cluster. We provide a step-by-step guide to help you set up SSH key authentification for passwordless connection. After executing the commands following this instruciton, you should be able to login the cluster without typing password.
 
 ## Contact
+
 If you encounter any problem following this instruction, please first have a look at the FAQ part and ask help if nothing helps:
 
 **Name:** Liu Yuxuan
@@ -13,41 +15,51 @@ If you encounter any problem following this instruction, please first have a loo
 **Position:** Teaching Assistant
 
 ## 1. Generate SSH Key Pair on Your Local Machine
+
 ```bash
 ## Execute the following commands on your local machine
 cd ~/.ssh
 ssh-keygen -t rsa -b 1024 -f csc4005_rsa -C "{Put Any Comment You Like}"
 ssh-add -K ./csc4005_rsa
 ```
+
 To check if you make it right, type the following command and you should see a string as the output.
+
 ```bash
 cat ~/.ssh/csc4005_rsa.pub
 ```
+
 **Notes:**
+
 - Execute ssh-keygen on your own computer instead of the cluster.
 - It is fine to use the SSH key file generated before (eg. id_rsa.pub), if you have.
 - ssh-keygen will ask you to set a paraphrase, which improves the security of using SSH key authentification. Type "Enter" for no paraphrase.
 
 **Parameters for ssh-keygen command:**
+
 - **-t**: type for ssh key generation. Here we use rsa
 - **-b**: bits
 - **-f**: name of your ssh key file. You are recommended to set this parameter in case it
-is conflict with the ssh key file you generated before.
+  is conflict with the ssh key file you generated before.
 - **-C**: comments to distinguish the ssh key file from others
 
 ## 2. Transfer Your SSH Public Key File to the Cluster
+
 ```bash
 ## Execute the following commands on your local machine
-scp ~/.ssh/csc4005_rsa.pub {Your Student ID}@10.26.200.21:~
+scp ~/.ssh/csc4005_rsa.pub {Your Student ID}@10.26.200.1:~
 ```
+
 **Notes:**
+
 - `{Your Student ID}` is where you put your student ID. Do not add the {} brackets in your command.
 - This command will ask you for password for data transfer. Please make sure that you type in the correct password. If you are Windows user and you want to copy & paste the password for convenience, try "Ctrl + Shift + V" if you fail to paste the password with "Ctrl + V".
 
 ## 3. Configure authorized_keys on the Cluster
+
 ```bash
 ## Login the cluster with password
-ssh {Your Student ID}@10.26.200.21
+ssh {Your Student ID}@10.26.200.1
 ## All the following commands should be executed on the cluster
 mkdir -p ~/.ssh
 cat ./csc4005_rsa.pub >> ~/.ssh/authorized_keys
@@ -55,42 +67,54 @@ rm -f ~/csc4005_rsa.pub
 chmod 700 ~/.ssh
 chmod 600 ~/.ssh/authorized_keys
 ```
+
 To check if you make it right, execute the following command and you should see a string as the output that is the same as in Step-1.
+
 ```bash
 cat ~/.ssh/authorized_keys
 ```
 
 ## 4. Prepare for SSH Connection with Key Authentification
+
 Add the following content to ~/.ssh/config file on your local machine:
+
 ```bash
 Host CSC4005_cluster
-    HostName 10.26.200.21
+    HostName 10.26.200.1
     IdentityFile ~/.ssh/csc4005_rsa
     User {Your Student ID}
 ```
+
 **Notes:**
+
 - It is recommended to configure with the RemoteSSH extension on VSCode. Please refer to [Remote Development using SSH](https://code.visualstudio.com/docs/remote/ssh) for more infomation.
 
 # 5. Login the Cluster Passwordlessly with SSH key Authentification
+
 ```bash
-ssh {Your Student ID}@10.26.200.21
+ssh {Your Student ID}@10.26.200.1
 ```
+
 or
+
 ```bash
 ssh {Your Student ID}@CSC4005_cluster
 ```
 
 ## FAQ
+
 ### 1. Why the password is still required to login the cluster after executing all the commands correctly in this instruction?
 
 **Answer:** Execute the following command and you will see detailed debug logs for your SSH connection. Check the logs and see if you could find out what is going wrong and fix it. If you are Mac user, you can also refer to this article [Troubleshooting passwordless login](https://help.dreamhost.com/hc/en-us/articles/215906508-Troubleshooting-passwordless-login) to see if it could help you. If nothing helps, take a screenshot of the output of the command, and send it to [118010200@link.cuhk.edu.cn](mailto:118010200@link.cuhk.edu.cn).
+
 ```bash
-ssh -vvv {Your Student ID}@10.26.200.21
+ssh -vvv {Your Student ID}@10.26.200.1
 ```
 
 ## Appendix
 
 ### How does SSH private/public key pair guarantees security of your connection?
+
 - **Step-1:** The client begins by sending an ID for the key pair it would like to authenticate with to the server.
 - **Step-2:** The server check's the authorized_keys file of the account that the client is attempting to log into for the key ID.
 - **Step-3:** If a public key with matching ID is found in the file, the server generates a random number and uses the public key to encrypt the number.

--- a/docs/docker_installation_guide.md
+++ b/docs/docker_installation_guide.md
@@ -22,13 +22,13 @@ For both containers, you can use either `docker pull` from Docker Hub online (ma
 or download the .tar file from the cluster login node, and use `docker load` to build image
 
 **Directory of Images .tar file on the Cluster**
+
 - With NVIDIA card (about 9GB):\
-  10.26.200.21:/CSC4005-resources/nvhpc:21.7-devel-cuda11.4-centos7.tar\
+  10.26.200.1:/CSC4005-resources/nvhpc:21.7-devel-cuda11.4-centos7.tar\
   All six parallel languages supported
 
-
 - Without NVIDIA card (about 670MB):\
-  10.26.200.21:/CSC4005-resources/centos7_csc4005.tar\
+  10.26.200.1:/CSC4005-resources/centos7_csc4005.tar\
   Only vectorization, MPI, Pthread, and OpenMP supported
 
 **Notes:**
@@ -78,7 +78,7 @@ Otherwise, you need to update your NVIDIA driver first if you want to use the nv
 # Pull docker image from nvidia
 # It may be slow pulling images from Docker hub.
 # As an alternative, we can download the .tar file from the cluster
-#   Directory on the cluster: 10.26.200.21:/CSC4005-resources/nvhpc:21.7-devel-cuda11.4-centos7.tar
+#   Directory on the cluster: 10.26.200.1:/CSC4005-resources/nvhpc:21.7-devel-cuda11.4-centos7.tar
 # After downloading, use docker load to build docker image from the .tar file
 docker pull nvcr.io/nvidia/nvhpc:21.7-devel-cuda11.4-centos7
 # or
@@ -108,7 +108,7 @@ docker container ps
 docker exec -it <CONTAINER ID> bash
 
 # Now, you can interact with the docker container just like a normal linux machine.
-# The followings are essential if your host's cuda driver version is high (e.g., latest 537.xx). In some older versions, they may be not necessary. You can check by yourself. 
+# The followings are essential if your host's cuda driver version is high (e.g., latest 537.xx). In some older versions, they may be not necessary. You can check by yourself.
 echo "export PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.7/compilers/bin:$PATH" >> ~/.bashrc
 echo "export PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.7/cuda/11.4/bin:$PATH" >> ~/.bashrc
 echo "export CUDA_TOOLKIT_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.7/cuda/11.4" >> ~/.bashrc
@@ -126,13 +126,13 @@ echo $LD_LIBRARY_PATH
 # We should see expected output for the following commands
 nvcc --version
 # nvcc: NVIDIA (R) Cuda compiler driver
-# Copyright (c) 2005-2021 NVIDIA Corporation    
+# Copyright (c) 2005-2021 NVIDIA Corporation
 # Built on Wed_Jun__2_19:15:15_PDT_2021
 # Cuda compilation tools, release 11.4, V11.4.48
-# Build cuda_11.4.r11.4/compiler.30033411_0     
+# Build cuda_11.4.r11.4/compiler.30033411_0
 
 pgc++ --version
-# pgc++ (aka nvc++) 21.7-0 64-bit target on x86-64 Linux -tp haswell 
+# pgc++ (aka nvc++) 21.7-0 64-bit target on x86-64 Linux -tp haswell
 # PGI Compilers and Tools
 # Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
 
@@ -157,7 +157,7 @@ This docker cannot compile & execute CUDA and OpenACC programs, but are fine wit
 # Pull a docker image of CentOS7 with basic MPI, Pthread, and OpenMP installed
 # It may be slow pulling images from Docker hub.
 # As an alternative, we can download the .tar file from the cluster
-#   Directory on the cluster: 10.26.200.21:/CSC4005-resources/centos7_csc4005.tar
+#   Directory on the cluster: 10.26.200.1:/CSC4005-resources/centos7_csc4005.tar
 # After downloading from the cluster, use docker load to build the image
 docker pull tonyyxliu/csc4005:centos7
 # or
@@ -256,17 +256,23 @@ docker info
 Docker Root Dir: /var/lib/docker
 ...
 ```
+
 This means that docker relies on WSL for file mapping, so we need to modify docker's file mapping path through wsl, which can be understood as file mounting.
 
 The docker-desktop-data disk image in WSL 2 mode is usually located at the following location:
+
 ```text
 C:\Users\<Your Name>\AppData\Local\Docker\wsl\data\ext4.vhdx
 ```
+
 Follow the instructions below to relocate it to a different drive/directory and keep all existing Docker data.
+
 - Exit Docker Desktop, then, open a command prompt (cmd):
+
 ```cmd
 wsl --list -v
 ```
+
 You should be able to see the states and make sure all states are stopped.
 
 ```cmd
@@ -276,13 +282,14 @@ docker-desktop-data   Stopped      2
 ```
 
 - Export docker-desktop-data to a file (backup image and related files) and then import back to WSL2, and set the path you want, use the following command:
+
 ```cmd
 wsl --export docker-desktop-data "D:\\docker-desktop-data.tar"
 wsl --unregister docker-desktop-data
 wsl --import docker-desktop-data "D:\\<You like>" "D:\\docker-desktop-data.tar" --version 2
 ```
+
 Please note that the C:\\Users\\<Your Name>\\AppData\\Local\\Docker\\wsl\\data\\ext4.vhdx file will be automatically deleted.
 
 Now start Docker Desktop and it will work normally.
 Don't forget to delete the D:\\docker-desktop-data.tar file last.
-


### PR DESCRIPTION
Old HPC IP is mentioned by two instructions in their commands/configurations/paths examples.

A global replacement of IP helps copy and paste from instructions.