### PR TITLE
Project 1: Disable FMA for GPU-based implementations

### DIFF
--- a/project1/src/gpu/CMakeLists.txt
+++ b/project1/src/gpu/CMakeLists.txt
@@ -16,6 +16,7 @@ endif ()
 SET(CMAKE_CXX_COMPILER pgc++)
 
 ## CUDA
+list(APPEND CUDA_NVCC_FLAGS "-fmad=false")
 cuda_add_executable(cuda_PartA
         cuda_PartA.cu
         ../utils.cpp ../utils.hpp)
@@ -32,7 +33,7 @@ cuda_add_executable(cuda_PartC
 target_link_libraries(cuda_PartC cudart)
 
 ## OpenACC
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -acc")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -acc -ta=tesla:nofma")
 add_executable(openacc_PartA
         openacc_PartA.cpp
         ../utils.cpp ../utils.hpp)


### PR DESCRIPTION
This patch disables [FMA](https://docs.nvidia.com/cuda/floating-point/index.html#the-fused-multiply-add-fma) for OpenACC and CUDA programs to ensure consistent floating-point results between CPU and GPU; my experiments indicate this change is necessary for alignment.

Additionally, while the current JPEG utility functions are [somewhat faulty](https://github.com/tonyyxliu/CUHKSZ-CSC4005/issues/71#issuecomment-2370816238), the errors are deterministic. This implies that we can use bit-exact equality for grading, as the pixel vector transformations must remain consistent for an implementation to be considered "correct". Comparing output images will suffice, as long as all programs use a unified I/O utility.

I can probably look into this issue with Triton implementations later.